### PR TITLE
ci: run Windows artifacts on main pushes

### DIFF
--- a/.github/workflows/windows-artifacts.yml
+++ b/.github/workflows/windows-artifacts.yml
@@ -6,6 +6,7 @@ name: Windows artifact build
   push:
     branches:
       - development
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Updates the Windows artifact workflow trigger so pushes to both `development` and `main` run the artifact build.

Scope:
- `.github/workflows/windows-artifacts.yml` only

Validation:
- Confirmed final diff changes only `.github/workflows/windows-artifacts.yml`
- Confirmed `workflow_dispatch` remains present
- Confirmed `pull_request` remains present
- Confirmed `push` branches include `development` and `main`
- Confirmed `actions/upload-artifact@v7` remains present
- Confirmed `retention-days: 14` remains present

This PR does not publish a release, create a tag, deploy anything, sign binaries, handle secrets, or modify chain/wallet/source code.